### PR TITLE
Use metadata to infer dataset axis order (zarr)

### DIFF
--- a/src/main/java/net/preibisch/mvrecon/fiji/datasetmanager/OMEZARR.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/datasetmanager/OMEZARR.java
@@ -234,11 +234,11 @@ public class OMEZARR implements MultiViewDatasetDefinition
 				return null;
 			}
 
-			// raw (reversed-from-metadata) data-dim indices of x,y,z by name; null if axes are
-			// missing/incomplete (fall back to {0,1,2}). scale, translation and getDimensions()
-			// all share this reversed order, so the same indices apply to each.
+			// raw data-dim indices of x,y,z,c,t (see AllenOMEZarrProperties.rawAxisIndices);
+			// scale/translation/getDimensions() share this order, so the same indices apply to each
 			final Axis[] axes = multiscales[ 0 ].axes;
-			final int[] xyz = AllenOMEZarrProperties.xyzAxesIndices( axes );
+			final int[] rawAxisIdx = AllenOMEZarrProperties.rawAxisIndices( axes );
+			final int[] xyz = rawAxisIdx != null ? new int[] { rawAxisIdx[ 0 ], rawAxisIdx[ 1 ], rawAxisIdx[ 2 ] } : null;
 
 			final OmeNgffDataset ds = multiscales[ 0 ].datasets[ 0 ];
 			double[] scale = null;
@@ -303,13 +303,11 @@ public class OMEZARR implements MultiViewDatasetDefinition
                 }
 			}
 
-			// channel/time data-dims located by TYPE (robust to non-standard ordering), falling back
-			// to the canonical positions 3/4 when the axis type metadata is missing
+			// channel/time dims from rawAxisIdx; fall back to positions 3/4 only if x/y/z couldn't
+			// be resolved by name at all (rawAxisIdx == null)
 			final long[] fullDims = fullScaleAttributes.getDimensions();
-			final int cRaw = AllenOMEZarrProperties.rawAxisIndexByType( axes, Axis.CHANNEL );
-			final int tRaw = AllenOMEZarrProperties.rawAxisIndexByType( axes, Axis.TIME );
-			final int cDim = cRaw >= 0 ? cRaw : 3;
-			final int tDim = tRaw >= 0 ? tRaw : 4;
+			final int cDim = rawAxisIdx != null && rawAxisIdx[ 3 ] >= 0 ? rawAxisIdx[ 3 ] : 3;
+			final int tDim = rawAxisIdx != null && rawAxisIdx[ 4 ] >= 0 ? rawAxisIdx[ 4 ] : 4;
 
 			if ( numDimensions == -1 )
 			{

--- a/src/main/java/net/preibisch/mvrecon/fiji/datasetmanager/OMEZARR.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/datasetmanager/OMEZARR.java
@@ -239,8 +239,8 @@ public class OMEZARR implements MultiViewDatasetDefinition
 			final Axis[] axes = multiscales[ 0 ].axes;
 
 			// validate dimensionality up front: scale/translation/getDimensions() are all
-			// axes[]-length arrays, and spatialTriple() below indexes them assuming at least 3
-			// entries, so a shorter array must be rejected here rather than crash there
+			// axes[]-length arrays, and spatialTriple() below indexes into them assuming at
+			// least 3 entries, so a shorter array must be rejected here rather than crash there
 			if ( axes.length != 3 && axes.length != 4 && axes.length != 5 )
 			{
 				IOFunctions.println( "Only 3D (xyz), 4D (xyzc), and 5D (xyzct) OME-ZARRs are allowed. stopping" );
@@ -271,8 +271,8 @@ public class OMEZARR implements MultiViewDatasetDefinition
 				translation = new double[] { 0, 0, 0 };
 
 			// keep the three spatial entries in true x,y,z order (not merely the first three)
-			scale = spatialTriple( scale, xyz );
-			translation = spatialTriple( translation, xyz );
+			scale = AllenOMEZarrProperties.spatialTriple( scale, xyz );
+			translation = AllenOMEZarrProperties.spatialTriple( translation, xyz );
 
 			String unit = "unknown";
 			for ( int d = 0; d < multiscales[ 0 ].axes.length; ++d )
@@ -304,7 +304,7 @@ public class OMEZARR implements MultiViewDatasetDefinition
 
                 // highest-resolution level = largest spatial voxel count (robust to axis order and
                 // to spatial axes the producer left un-downsampled; comparing one raw dim is not)
-                final long[] sp = spatialTriple( attr.getDimensions(), xyz );
+                final long[] sp = AllenOMEZarrProperties.spatialTriple( attr.getDimensions(), xyz );
                 final long vol = sp[ 0 ] * sp[ 1 ] * sp[ 2 ];
                 if ( fullScaleAttributes == null || vol > fullScaleVol )
                 {
@@ -348,7 +348,7 @@ public class OMEZARR implements MultiViewDatasetDefinition
 			}
 
 			// resolved x,y,z size for this dataset (used for the ViewSetup size, see spatialDimsMap)
-			spatialDimsMap.put( dataset, spatialTriple( fullDims, xyz ) );
+			spatialDimsMap.put( dataset, AllenOMEZarrProperties.spatialTriple( fullDims, xyz ) );
 
 			if ( numDimensions != 3 && numDimensions != 4 && numDimensions != 5 )
 			{
@@ -910,19 +910,6 @@ public class OMEZARR implements MultiViewDatasetDefinition
 		}
 
 		return entries;
-	}
-
-	// the three spatial (x,y,z) entries of a per-axis array (dimensions/scale/translation, all in
-	// reversed n5 order); xyz = raw indices from AllenOMEZarrProperties.xyzAxesIndices, or null to
-	// take the first three (standard order). Overloaded for long[] and double[].
-	private static long[] spatialTriple( final long[] a, final int[] xyz )
-	{
-		return xyz == null ? new long[] { a[ 0 ], a[ 1 ], a[ 2 ] } : new long[] { a[ xyz[ 0 ] ], a[ xyz[ 1 ] ], a[ xyz[ 2 ] ] };
-	}
-
-	private static double[] spatialTriple( final double[] a, final int[] xyz )
-	{
-		return xyz == null ? new double[] { a[ 0 ], a[ 1 ], a[ 2 ] } : new double[] { a[ xyz[ 0 ] ], a[ xyz[ 1 ] ], a[ xyz[ 2 ] ] };
 	}
 
 	protected static boolean hasCommonScale( final Map< String, Pair< DatasetAttributes, Pair< VoxelDimensions, double[] > > > attr )

--- a/src/main/java/net/preibisch/mvrecon/fiji/datasetmanager/OMEZARR.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/datasetmanager/OMEZARR.java
@@ -237,6 +237,16 @@ public class OMEZARR implements MultiViewDatasetDefinition
 			// raw data-dim indices of x,y,z,c,t (see AllenOMEZarrProperties.rawAxisIndices);
 			// scale/translation/getDimensions() share this order, so the same indices apply to each
 			final Axis[] axes = multiscales[ 0 ].axes;
+
+			// validate dimensionality up front: scale/translation/getDimensions() are all
+			// axes[]-length arrays, and spatialTriple() below indexes them assuming at least 3
+			// entries, so a shorter array must be rejected here rather than crash there
+			if ( axes.length != 3 && axes.length != 4 && axes.length != 5 )
+			{
+				IOFunctions.println( "Only 3D (xyz), 4D (xyzc), and 5D (xyzct) OME-ZARRs are allowed. stopping" );
+				return null;
+			}
+
 			final int[] rawAxisIdx = AllenOMEZarrProperties.rawAxisIndices( axes );
 			final int[] xyz = rawAxisIdx != null ? new int[] { rawAxisIdx[ 0 ], rawAxisIdx[ 1 ], rawAxisIdx[ 2 ] } : null;
 

--- a/src/main/java/net/preibisch/mvrecon/fiji/datasetmanager/OMEZARR.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/datasetmanager/OMEZARR.java
@@ -57,6 +57,7 @@ import javax.swing.JLabel;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.universe.StorageFormat;
+import org.janelia.saalfeldlab.n5.universe.metadata.axes.Axis;
 import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.OmeNgffMultiScaleMetadata;
 import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.OmeNgffMultiScaleMetadata.OmeNgffDataset;
 import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.coordinateTransformations.CoordinateTransformation;
@@ -93,6 +94,7 @@ import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
 import net.preibisch.mvrecon.fiji.spimdata.boundingbox.BoundingBoxes;
 import net.preibisch.mvrecon.fiji.spimdata.imgloaders.AllenOMEZarrLoader;
 import net.preibisch.mvrecon.fiji.spimdata.imgloaders.AllenOMEZarrLoader.OMEZARREntry;
+import net.preibisch.mvrecon.fiji.spimdata.imgloaders.AllenOMEZarrProperties;
 import net.preibisch.mvrecon.fiji.spimdata.intensityadjust.IntensityAdjustments;
 import net.preibisch.mvrecon.fiji.spimdata.interestpoints.ViewInterestPoints;
 import net.preibisch.mvrecon.fiji.spimdata.pointspreadfunctions.PointSpreadFunctions;
@@ -194,6 +196,10 @@ public class OMEZARR implements MultiViewDatasetDefinition
 		//
 		final HashMap< String, Pair< DatasetAttributes, Pair< VoxelDimensions, double[] > > > attrMap = new HashMap<>();
 
+		// per-dataset x,y,z size resolved from the OME-NGFF axes, so a non-standard axis order
+		// yields the correct ViewSetup size instead of the raw, reversed n5 getDimensions().
+		final HashMap< String, long[] > spatialDimsMap = new HashMap<>();
+
 		int numDimensions = -1;
 		long sizeC = -1;
 		long sizeT = -1;
@@ -228,6 +234,12 @@ public class OMEZARR implements MultiViewDatasetDefinition
 				return null;
 			}
 
+			// raw (reversed-from-metadata) data-dim indices of x,y,z by name; null if axes are
+			// missing/incomplete (fall back to {0,1,2}). scale, translation and getDimensions()
+			// all share this reversed order, so the same indices apply to each.
+			final Axis[] axes = multiscales[ 0 ].axes;
+			final int[] xyz = AllenOMEZarrProperties.xyzAxesIndices( axes );
+
 			final OmeNgffDataset ds = multiscales[ 0 ].datasets[ 0 ];
 			double[] scale = null;
 			double[] translation = null;
@@ -248,11 +260,9 @@ public class OMEZARR implements MultiViewDatasetDefinition
 			if ( translation == null )
 				translation = new double[] { 0, 0, 0 };
 
-			if ( scale.length > 3 )
-				scale = new double[] { scale[ 0 ], scale[ 1 ], scale[ 2 ] };
-
-			if ( translation.length > 3 )
-				translation = new double[] { translation[ 0 ], translation[ 1 ], translation[ 2 ] };
+			// keep the three spatial entries in true x,y,z order (not merely the first three)
+			scale = spatialTriple( scale, xyz );
+			translation = spatialTriple( translation, xyz );
 
 			String unit = "unknown";
 			for ( int d = 0; d < multiscales[ 0 ].axes.length; ++d )
@@ -269,6 +279,7 @@ public class OMEZARR implements MultiViewDatasetDefinition
 			IOFunctions.println( multiscales[ 0 ].datasets.length + " resolution steps." );
 
 			DatasetAttributes fullScaleAttributes = null;
+			long fullScaleVol = -1;
 
 			for ( final OmeNgffDataset level : multiscales[ 0 ].datasets )
 			{
@@ -281,23 +292,31 @@ public class OMEZARR implements MultiViewDatasetDefinition
                 IOFunctions.println("BlockSize: " + Arrays.toString(attr.getBlockSize()));
                 IOFunctions.println("DataType: " + attr.getDataType());
 
-                if (fullScaleAttributes == null || attr.getDimensions()[0] > fullScaleAttributes.getDimensions()[0])
+                // highest-resolution level = largest spatial voxel count (robust to axis order and
+                // to spatial axes the producer left un-downsampled; comparing one raw dim is not)
+                final long[] sp = spatialTriple( attr.getDimensions(), xyz );
+                final long vol = sp[ 0 ] * sp[ 1 ] * sp[ 2 ];
+                if ( fullScaleAttributes == null || vol > fullScaleVol )
+                {
                     fullScaleAttributes = attr;
+                    fullScaleVol = vol;
+                }
 			}
+
+			// channel/time data-dims located by TYPE (robust to non-standard ordering), falling back
+			// to the canonical positions 3/4 when the axis type metadata is missing
+			final long[] fullDims = fullScaleAttributes.getDimensions();
+			final int cRaw = AllenOMEZarrProperties.rawAxisIndexByType( axes, Axis.CHANNEL );
+			final int tRaw = AllenOMEZarrProperties.rawAxisIndexByType( axes, Axis.TIME );
+			final int cDim = cRaw >= 0 ? cRaw : 3;
+			final int tDim = tRaw >= 0 ? tRaw : 4;
 
 			if ( numDimensions == -1 )
 			{
 				numDimensions = fullScaleAttributes.getNumDimensions();
 
-				if ( numDimensions >=4 )
-				{
-					sizeC = fullScaleAttributes.getDimensions()[ 3 ];
-				}
-
-			if ( numDimensions >=5 )
-			{
-				sizeT = fullScaleAttributes.getDimensions()[ 4 ];
-				}
+				if ( numDimensions >= 4 ) sizeC = fullDims[ cDim ];
+				if ( numDimensions >= 5 ) sizeT = fullDims[ tDim ];
 			}
 			else
 			{
@@ -307,18 +326,21 @@ public class OMEZARR implements MultiViewDatasetDefinition
 					return null;
 				}
 
-				if ( numDimensions >=4 && sizeC != fullScaleAttributes.getDimensions()[ 3 ] )
+				if ( numDimensions >= 4 && sizeC != fullDims[ cDim ] )
 				{
-					IOFunctions.println( "numDimensions mismatch for sizeC [3] in dataset dimensions. stopping" );
+					IOFunctions.println( "sizeC (channel axis) mismatch across datasets. stopping" );
 					return null;
 				}
 
-				if ( numDimensions >=5 && sizeT != fullScaleAttributes.getDimensions()[ 4 ] )
+				if ( numDimensions >= 5 && sizeT != fullDims[ tDim ] )
 				{
-					IOFunctions.println( "numDimensions mismatch for sizeT [4] in dataset dimensions. stopping" );
+					IOFunctions.println( "sizeT (time axis) mismatch across datasets. stopping" );
 					return null;
 				}
 			}
+
+			// resolved x,y,z size for this dataset (used for the ViewSetup size, see spatialDimsMap)
+			spatialDimsMap.put( dataset, spatialTriple( fullDims, xyz ) );
 
 			if ( numDimensions != 3 && numDimensions != 4 && numDimensions != 5 )
 			{
@@ -740,6 +762,7 @@ public class OMEZARR implements MultiViewDatasetDefinition
 
 			// we need the metadata
 			final Pair<DatasetAttributes, Pair<VoxelDimensions, double[]>> meta = attrMap.get( dataset );
+			final long[] spatialDims = spatialDimsMap.get( dataset );
 
 			// has a pattern, so we need to load and update the metadata
 			if ( tileId >= 0 && meta.getB().getB() != null )
@@ -755,14 +778,14 @@ public class OMEZARR implements MultiViewDatasetDefinition
 			if ( chId >= 0 )
 			{
 				// channel had a pattern, so it's a single channel for this dataset, still possibly multiple timepoints
-				viewIdToPath.putAll( updateViewSetup(dataset, viewSetups, meta, angleId, chId, illumId, tileId, tpId, sizeT, numDimensions ) );
+				viewIdToPath.putAll( updateViewSetup(dataset, viewSetups, meta, spatialDims, angleId, chId, illumId, tileId, tpId, sizeT, numDimensions ) );
 			}
 			else
 			{
 				// if the channels are inside the 4D/5D OME-ZARR, this dataset could contain more than one ViewSetup
                 // if 3D OME-ZARR with no channel pattern (sizeC=0), create 1 channel (channelID 0)
 				for ( int c = 0; c < Math.max(1, sizeC); ++c )
-					viewIdToPath.putAll( updateViewSetup( dataset, viewSetups, meta, angleId, c, illumId, tileId, tpId, sizeT, numDimensions ) );
+					viewIdToPath.putAll( updateViewSetup( dataset, viewSetups, meta, spatialDims, angleId, c, illumId, tileId, tpId, sizeT, numDimensions ) );
 			}
 		}
 
@@ -807,6 +830,7 @@ public class OMEZARR implements MultiViewDatasetDefinition
 			final String dataset,
 			final Collection< ViewSetup > viewSetups,
 			final Pair<DatasetAttributes, Pair<VoxelDimensions, double[]>> meta,
+			final long[] spatialDims,
 			final int angleId,
 			final int channelId,
 			final int illumId,
@@ -823,7 +847,8 @@ public class OMEZARR implements MultiViewDatasetDefinition
 			{
 				IOFunctions.println( "ViewSetupId: " + vs.getId() );
 
-				vs.setSize( new FinalDimensions( meta.getA().getDimensions() ) );
+				// axis-resolved x,y,z size, not raw getDimensions() (reversed, and 4D/5D includes c/t)
+				vs.setSize( new FinalDimensions( spatialDims ) );
 				vs.setVoxelSize( meta.getB().getA() );
 
 				if ( tpId >= 0 )
@@ -877,6 +902,19 @@ public class OMEZARR implements MultiViewDatasetDefinition
 		}
 
 		return entries;
+	}
+
+	// the three spatial (x,y,z) entries of a per-axis array (dimensions/scale/translation, all in
+	// reversed n5 order); xyz = raw indices from AllenOMEZarrProperties.xyzAxesIndices, or null to
+	// take the first three (standard order). Overloaded for long[] and double[].
+	private static long[] spatialTriple( final long[] a, final int[] xyz )
+	{
+		return xyz == null ? new long[] { a[ 0 ], a[ 1 ], a[ 2 ] } : new long[] { a[ xyz[ 0 ] ], a[ xyz[ 1 ] ], a[ xyz[ 2 ] ] };
+	}
+
+	private static double[] spatialTriple( final double[] a, final int[] xyz )
+	{
+		return xyz == null ? new double[] { a[ 0 ], a[ 1 ], a[ 2 ] } : new double[] { a[ xyz[ 0 ] ], a[ xyz[ 1 ] ], a[ xyz[ 2 ] ] };
 	}
 
 	protected static boolean hasCommonScale( final Map< String, Pair< DatasetAttributes, Pair< VoxelDimensions, double[] > > > attr )

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/AllenOMEZarrLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/AllenOMEZarrLoader.java
@@ -27,6 +27,7 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.Map;
 
+import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.universe.StorageFormat;
 
 import bdv.ViewerSetupImgLoader;
@@ -58,16 +59,34 @@ public class AllenOMEZarrLoader extends N5ImageLoader
 	 */
 	private final StorageFormat format;
 
+	// kept locally (in addition to being handed to the N5ImageLoader superclass) so
+	// prepareCachedImage() below can query axes metadata to correct the spatial axis
+	// order of the volume built by the superclass, see correctSpatialAxesOrder()
+	private final N5Reader n5Reader;
+
+	private AllenOMEZarrProperties allenProperties;
+
 	public AllenOMEZarrLoader(
 			final URI n5URI,
 			final StorageFormat format,
 			final AbstractSequenceDescription< ?, ?, ? > sequenceDescription,
 			final Map< ViewId, OMEZARREntry > viewIdToPath )
 	{
-		super( URITools.instantiateN5Reader( format, n5URI ), n5URI, sequenceDescription );
+		this( n5URI, format, sequenceDescription, viewIdToPath, URITools.instantiateN5Reader( format, n5URI ) );
+	}
+
+	private AllenOMEZarrLoader(
+			final URI n5URI,
+			final StorageFormat format,
+			final AbstractSequenceDescription< ?, ?, ? > sequenceDescription,
+			final Map< ViewId, OMEZARREntry > viewIdToPath,
+			final N5Reader n5Reader )
+	{
+		super( n5Reader, n5URI, sequenceDescription );
 		this.sequenceDescription = sequenceDescription;
 		this.format = format;
 		this.viewIdToPath = viewIdToPath;
+		this.n5Reader = n5Reader;
 	}
 
 	public Map< ViewId, OMEZARREntry > getViewIdToPath()
@@ -78,7 +97,48 @@ public class AllenOMEZarrLoader extends N5ImageLoader
 	@Override
 	protected N5Properties createN5PropertiesInstance()
 	{
-		return new AllenOMEZarrProperties( sequenceDescription, viewIdToPath );
+		return allenProperties = new AllenOMEZarrProperties( sequenceDescription, viewIdToPath );
+	}
+
+	/**
+	 * The volume built by {@code N5ImageLoader.prepareCachedImage()} (superclass) is
+	 * constructed directly from the raw, n5-zarr-reported dimension order, which is
+	 * only correct if the producer declared the standard TCZYX (metadata) / XYZCT
+	 * (data) axes convention. Some producers may
+	 * declare a different, equally NGFF-valid axes order (e.g. axes=[x,y,z] instead
+	 * of [z,y,x]), in which case the raw volume has its spatial axes out of order
+	 * (e.g. X and Z swapped) - which looks like a rotated/transposed image. Use the
+	 * declared axes metadata to permute the spatial axes (0,1,2) back into true
+	 * X,Y,Z order before any higher-dimension (channel/timepoint) hyperslicing.
+	 */
+	private < T > RandomAccessibleInterval< T > correctSpatialAxesOrder( final RandomAccessibleInterval< T > vol, final int setupId, final int timepointId )
+	{
+		if ( allenProperties == null || n5Reader == null )
+			return vol;
+
+		final int[] rawXYZ = allenProperties.getRawSpatialAxesIndices( n5Reader, setupId, timepointId );
+		if ( rawXYZ == null )
+			return vol; // axes metadata missing/incomplete: assume the volume is already in X,Y,Z order
+
+		// bring true X to position 0 and true Y to position 1 via at most two pairwise
+		// axis swaps (any permutation of 3 elements decomposes into <= 2 transpositions);
+		// Z then ends up correctly at position 2 automatically. 'cur[k]' is the raw-dim
+		// index currently sitting at position k of 'out'.
+		RandomAccessibleInterval< T > out = vol;
+		final int[] cur = { 0, 1, 2 };
+		for ( int t = 0; t < 2; ++t )
+		{
+			if ( cur[ t ] == rawXYZ[ t ] )
+				continue;
+
+			final int at = ( t == 0 && cur[ 1 ] == rawXYZ[ 0 ] ) ? 1 : 2;
+			out = Views.permute( out, t, at );
+			final int tmp = cur[ t ];
+			cur[ t ] = cur[ at ];
+			cur[ at ] = tmp;
+		}
+
+		return out;
 	}
 
 	public StorageFormat getFormat() { return format; }
@@ -151,7 +211,10 @@ public class AllenOMEZarrLoader extends N5ImageLoader
 			final CacheHints cacheHints,
 			final T type )
 	{
-		return viewIdToPath.get( new ViewId(timepointId, setupId) ).extract3DVolume( super.prepareCachedImage( datasetPath, setupId, timepointId, level, cacheHints, type ) );
+		final RandomAccessibleInterval< T > vol = correctSpatialAxesOrder(
+				super.prepareCachedImage( datasetPath, setupId, timepointId, level, cacheHints, type ),
+				setupId, timepointId );
+		return viewIdToPath.get( new ViewId(timepointId, setupId) ).extract3DVolume( vol );
 		//return Views.hyperSlice( Views.hyperSlice( super.prepareCachedImage( datasetPath, setupId, 0, level, cacheHints, type ), 4, 0 ), 3, 0);
 		/*
 		return super.prepareCachedImage( datasetPath, setupId, 0, level, cacheHints, type ).view()

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/AllenOMEZarrLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/AllenOMEZarrLoader.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.universe.StorageFormat;
+import org.janelia.saalfeldlab.n5.universe.metadata.axes.AxisUtils;
 
 import bdv.ViewerSetupImgLoader;
 import bdv.img.n5.N5ImageLoader;
@@ -131,29 +132,8 @@ public class AllenOMEZarrLoader extends N5ImageLoader
 		if ( m != n || !isPermutation( desired ) )
 			return vol;
 
-		// realize the permutation via pairwise swaps: after step q, position q holds its target;
-		// cur[k] is the raw dim currently at position k. desired[q] still sits in cur[q+1..n-1].
-		RandomAccessibleInterval< T > out = vol;
-		final int[] cur = new int[ n ];
-		for ( int k = 0; k < n; ++k )
-			cur[ k ] = k;
-
-		for ( int q = 0; q < n; ++q )
-		{
-			if ( cur[ q ] == desired[ q ] )
-				continue;
-
-			int from = q + 1;
-			while ( cur[ from ] != desired[ q ] )
-				++from;
-
-			out = Views.permute( out, q, from );
-			final int tmp = cur[ q ];
-			cur[ q ] = cur[ from ];
-			cur[ from ] = tmp;
-		}
-
-		return out;
+		// desired[] is destination->source; AxisUtils.permute() wants source->destination
+		return AxisUtils.permute( vol, AxisUtils.invertPermutation( desired ) );
 	}
 
 	// true iff a[] is a permutation of 0..a.length-1

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/AllenOMEZarrLoader.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/AllenOMEZarrLoader.java
@@ -101,44 +101,72 @@ public class AllenOMEZarrLoader extends N5ImageLoader
 	}
 
 	/**
-	 * The volume built by {@code N5ImageLoader.prepareCachedImage()} (superclass) is
-	 * constructed directly from the raw, n5-zarr-reported dimension order, which is
-	 * only correct if the producer declared the standard TCZYX (metadata) / XYZCT
-	 * (data) axes convention. Some producers may
-	 * declare a different, equally NGFF-valid axes order (e.g. axes=[x,y,z] instead
-	 * of [z,y,x]), in which case the raw volume has its spatial axes out of order
-	 * (e.g. X and Z swapped) - which looks like a rotated/transposed image. Use the
-	 * declared axes metadata to permute the spatial axes (0,1,2) back into true
-	 * X,Y,Z order before any higher-dimension (channel/timepoint) hyperslicing.
+	 * Permute the raw, n5-zarr-reported volume into canonical X,Y,Z,(C),(T) data order using the
+	 * declared axes metadata (spatial axes by name, channel/time by type; see
+	 * {@link AllenOMEZarrProperties#getRawAxisIndices}). OME-NGFF does not require the canonical
+	 * order, so a producer may declare e.g. axes=[x,y,z] instead of [z,y,x] (looks transposed) or
+	 * put channel/time off their usual positions (would swap c/t in the positional hyperslicing of
+	 * {@link OMEZARREntry#extract3DVolume}); reordering here makes that downstream slicing correct
+	 * by construction.
 	 */
-	private < T > RandomAccessibleInterval< T > correctSpatialAxesOrder( final RandomAccessibleInterval< T > vol, final int setupId, final int timepointId )
+	private < T > RandomAccessibleInterval< T > reorderToCanonicalAxes( final RandomAccessibleInterval< T > vol, final int setupId, final int timepointId )
 	{
 		if ( allenProperties == null || n5Reader == null )
 			return vol;
 
-		final int[] rawXYZ = allenProperties.getRawSpatialAxesIndices( n5Reader, setupId, timepointId );
-		if ( rawXYZ == null )
-			return vol; // axes metadata missing/incomplete: assume the volume is already in X,Y,Z order
+		final int[] raw = allenProperties.getRawAxisIndices( n5Reader, setupId, timepointId ); // { xRaw, yRaw, zRaw, cRaw, tRaw }
+		if ( raw == null )
+			return vol; // axes metadata missing/incomplete: assume the volume is already canonical
 
-		// bring true X to position 0 and true Y to position 1 via at most two pairwise
-		// axis swaps (any permutation of 3 elements decomposes into <= 2 transpositions);
-		// Z then ends up correctly at position 2 automatically. 'cur[k]' is the raw-dim
-		// index currently sitting at position k of 'out'.
+		// desired[p] = raw dim that belongs at output position p, in canonical order X,Y,Z,(C),(T),
+		// keeping only declared axes (raw[i] >= 0). Bail unless it maps every dim distinctly (i.e.
+		// the metadata agrees with the data), rather than applying a bogus permutation.
+		final int n = vol.numDimensions();
+		final int[] desired = new int[ n ];
+		int m = 0;
+		for ( final int r : raw )
+			if ( r >= 0 && m < n )
+				desired[ m++ ] = r;
+
+		if ( m != n || !isPermutation( desired ) )
+			return vol;
+
+		// realize the permutation via pairwise swaps: after step q, position q holds its target;
+		// cur[k] is the raw dim currently at position k. desired[q] still sits in cur[q+1..n-1].
 		RandomAccessibleInterval< T > out = vol;
-		final int[] cur = { 0, 1, 2 };
-		for ( int t = 0; t < 2; ++t )
+		final int[] cur = new int[ n ];
+		for ( int k = 0; k < n; ++k )
+			cur[ k ] = k;
+
+		for ( int q = 0; q < n; ++q )
 		{
-			if ( cur[ t ] == rawXYZ[ t ] )
+			if ( cur[ q ] == desired[ q ] )
 				continue;
 
-			final int at = ( t == 0 && cur[ 1 ] == rawXYZ[ 0 ] ) ? 1 : 2;
-			out = Views.permute( out, t, at );
-			final int tmp = cur[ t ];
-			cur[ t ] = cur[ at ];
-			cur[ at ] = tmp;
+			int from = q + 1;
+			while ( cur[ from ] != desired[ q ] )
+				++from;
+
+			out = Views.permute( out, q, from );
+			final int tmp = cur[ q ];
+			cur[ q ] = cur[ from ];
+			cur[ from ] = tmp;
 		}
 
 		return out;
+	}
+
+	// true iff a[] is a permutation of 0..a.length-1
+	private static boolean isPermutation( final int[] a )
+	{
+		final boolean[] seen = new boolean[ a.length ];
+		for ( final int v : a )
+		{
+			if ( v < 0 || v >= a.length || seen[ v ] )
+				return false;
+			seen[ v ] = true;
+		}
+		return true;
 	}
 
 	public StorageFormat getFormat() { return format; }
@@ -211,7 +239,7 @@ public class AllenOMEZarrLoader extends N5ImageLoader
 			final CacheHints cacheHints,
 			final T type )
 	{
-		final RandomAccessibleInterval< T > vol = correctSpatialAxesOrder(
+		final RandomAccessibleInterval< T > vol = reorderToCanonicalAxes(
 				super.prepareCachedImage( datasetPath, setupId, timepointId, level, cacheHints, type ),
 				setupId, timepointId );
 		return viewIdToPath.get( new ViewId(timepointId, setupId) ).extract3DVolume( vol );

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/AllenOMEZarrProperties.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/AllenOMEZarrProperties.java
@@ -137,7 +137,7 @@ public class AllenOMEZarrProperties implements N5Properties
 		return xyzAxesIndices( getViewSetupMultiscaleMetadata( n5, timepointId, setupId ).axes );
 	}
 
-	private static int[] xyzAxesIndices( final Axis[] axes )
+	public static int[] xyzAxesIndices( final Axis[] axes )
 	{
 		if ( axes == null )
 			return null;
@@ -151,6 +151,38 @@ public class AllenOMEZarrProperties implements N5Properties
 					idx[ d ] = axes.length - 1 - i; // dimensions[]/scale[]/translation[] are axes[] reversed
 
 		return ( idx[ 0 ] < 0 || idx[ 1 ] < 0 || idx[ 2 ] < 0 ) ? null : idx;
+	}
+
+	/**
+	 * Raw (reversed-from-metadata) dimension index of each canonical axis, as
+	 * {@code { xRaw, yRaw, zRaw, cRaw, tRaw }} (x/y/z by name, c/t by type; cRaw/tRaw are -1 when
+	 * that axis is not declared), or {@code null} if the axes metadata does not name all of x,y,z
+	 * (callers then assume the standard XYZCT order).
+	 */
+	public int[] getRawAxisIndices( final N5Reader n5, final int setupId, final int timepointId )
+	{
+		final Axis[] axes = getViewSetupMultiscaleMetadata( n5, timepointId, setupId ).axes;
+		final int[] xyz = xyzAxesIndices( axes );
+		if ( xyz == null )
+			return null;
+
+		return new int[] { xyz[ 0 ], xyz[ 1 ], xyz[ 2 ], rawAxisIndexByType( axes, Axis.CHANNEL ), rawAxisIndexByType( axes, Axis.TIME ) };
+	}
+
+	/**
+	 * Raw (reversed-from-metadata) dimension index of the axis with the given OME-NGFF
+	 * {@code type} ({@link Axis#CHANNEL}/{@link Axis#TIME}), or -1 if none. Channel and time are
+	 * matched by type since - unlike the three {@code type=space} axes told apart by x/y/z name -
+	 * their type is a more reliable discriminator than the non-standardized axis name.
+	 */
+	public static int rawAxisIndexByType( final Axis[] axes, final String type )
+	{
+		if ( axes != null )
+			for ( int i = 0; i < axes.length; ++i )
+				if ( type.equalsIgnoreCase( axes[ i ].getType() ) )
+					return axes.length - 1 - i; // dimensions[] is axes[] reversed
+
+		return -1;
 	}
 
 	//

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/AllenOMEZarrProperties.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/AllenOMEZarrProperties.java
@@ -22,7 +22,6 @@
  */
 package net.preibisch.mvrecon.fiji.spimdata.imgloaders;
 
-import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -30,6 +29,7 @@ import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.universe.metadata.axes.Axis;
+import org.janelia.saalfeldlab.n5.universe.metadata.axes.AxisUtils;
 import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.OmeNgffMetadata;
 import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.OmeNgffMultiScaleMetadata;
 import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.OmeNgffMultiScaleMetadata.OmeNgffDataset;
@@ -108,11 +108,29 @@ public class AllenOMEZarrProperties implements N5Properties
 		final String path = getMultiscaleDatasetPathOrDefault(n5, timepointId, setupId, level);
 		final long[] dimensions = n5.getDatasetAttributes( path ).getDimensions();
 
-		final int[] xyz = getRawSpatialAxesIndices( n5, setupId, timepointId );
-		if ( xyz == null )
-			return Arrays.copyOf( dimensions, 3 ); // axes metadata missing/incomplete: assume standard TCZYX/XYZCT order
+		return spatialTriple( dimensions, getRawSpatialAxesIndices( n5, setupId, timepointId ) );
+	}
 
-		return new long[] { dimensions[ xyz[ 0 ] ], dimensions[ xyz[ 1 ] ], dimensions[ xyz[ 2 ] ] };
+	/**
+	 * The three spatial (x,y,z) entries of a per-axis array (dimensions/scale/translation, all in
+	 * reversed n5 order), in true x,y,z order; xyz = raw indices from {@link #xyzAxesIndices}, or
+	 * {@code null} to assume the standard {0,1,2} order. Overloaded for long[] and double[].
+	 */
+	public static long[] spatialTriple( final long[] a, final int[] xyz )
+	{
+		final int[] r = xyzOrDefault( xyz );
+		return new long[] { a[ r[ 0 ] ], a[ r[ 1 ] ], a[ r[ 2 ] ] };
+	}
+
+	public static double[] spatialTriple( final double[] a, final int[] xyz )
+	{
+		final int[] r = xyzOrDefault( xyz );
+		return new double[] { a[ r[ 0 ] ], a[ r[ 1 ] ], a[ r[ 2 ] ] };
+	}
+
+	private static int[] xyzOrDefault( final int[] xyz )
+	{
+		return xyz != null ? xyz : new int[] { 0, 1, 2 };
 	}
 
 	/**
@@ -142,15 +160,19 @@ public class AllenOMEZarrProperties implements N5Properties
 		if ( axes == null )
 			return null;
 
-		final String[] xyz = { "x", "y", "z" };
-		final int[] idx = { -1, -1, -1 };
-
-		for ( int i = 0; i < axes.length; ++i )
-			for ( int d = 0; d < 3; ++d )
-				if ( xyz[ d ].equalsIgnoreCase( axes[ i ].getName() ) )
-					idx[ d ] = axes.length - 1 - i; // dimensions[]/scale[]/translation[] are axes[] reversed
+		final int[] idx = {
+				rawAxisIndexByName( axes, "x" ),
+				rawAxisIndexByName( axes, "y" ),
+				rawAxisIndexByName( axes, "z" ) };
 
 		return ( idx[ 0 ] < 0 || idx[ 1 ] < 0 || idx[ 2 ] < 0 ) ? null : idx;
+	}
+
+	// last (i.e. lowest raw index) axis matching the given name, case-insensitively, or -1 if none
+	private static int rawAxisIndexByName( final Axis[] axes, final String name )
+	{
+		final int[] matches = AxisUtils.indexes( axes, a -> name.equalsIgnoreCase( a.getName() ) );
+		return matches.length == 0 ? -1 : axes.length - 1 - matches[ matches.length - 1 ];
 	}
 
 	/** See {@link #rawAxisIndices(Axis[])}. */
@@ -204,12 +226,11 @@ public class AllenOMEZarrProperties implements N5Properties
 	 */
 	public static int rawAxisIndexByType( final Axis[] axes, final String type )
 	{
-		if ( axes != null )
-			for ( int i = 0; i < axes.length; ++i )
-				if ( type.equalsIgnoreCase( axes[ i ].getType() ) )
-					return axes.length - 1 - i; // dimensions[] is axes[] reversed
+		if ( axes == null )
+			return -1;
 
-		return -1;
+		final int[] matches = AxisUtils.indexes( axes, a -> type.equalsIgnoreCase( a.getType() ) );
+		return matches.length == 0 ? -1 : axes.length - 1 - matches[ 0 ];
 	}
 
 	//
@@ -270,8 +291,7 @@ public class AllenOMEZarrProperties implements N5Properties
 		// index of x/y/z within the raw (reversed) scale/translation arrays - see
 		// getRawSpatialAxesIndices(); falls back to the standard TCZYX/XYZCT position
 		// (0,1,2) if the axes metadata is missing or incomplete
-		final int[] xyzIdx = xyzAxesIndices( multiScaleMetadata.axes );
-		final int[] raw = xyzIdx != null ? xyzIdx : new int[] { 0, 1, 2 };
+		final int[] raw = xyzOrDefault( xyzAxesIndices( multiScaleMetadata.axes ) );
 
 		// iterate over all resolution levels for scale
 		for ( int s = 0; s < multiScaleMetadata.datasets.length; ++s )

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/AllenOMEZarrProperties.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/AllenOMEZarrProperties.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.universe.metadata.axes.Axis;
 import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.OmeNgffMetadata;
 import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.OmeNgffMultiScaleMetadata;
 import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.OmeNgffMultiScaleMetadata.OmeNgffDataset;
@@ -106,8 +107,50 @@ public class AllenOMEZarrProperties implements N5Properties
 	{
 		final String path = getMultiscaleDatasetPathOrDefault(n5, timepointId, setupId, level);
 		final long[] dimensions = n5.getDatasetAttributes( path ).getDimensions();
-		// dataset dimensions is 5D, remove the channel and time dimensions
-		return Arrays.copyOf( dimensions, 3 );
+
+		final int[] xyz = getRawSpatialAxesIndices( n5, setupId, timepointId );
+		if ( xyz == null )
+			return Arrays.copyOf( dimensions, 3 ); // axes metadata missing/incomplete: assume standard TCZYX/XYZCT order
+
+		return new long[] { dimensions[ xyz[ 0 ] ], dimensions[ xyz[ 1 ] ], dimensions[ xyz[ 2 ] ] };
+	}
+
+	/**
+	 * Index of the x, y, and z axes (in that order) within the RAW dimension order used
+	 * by the underlying N5/n5-zarr {@code CellGrid} / {@code RandomAccessibleInterval},
+	 * which is the reverse of the declared OME-NGFF {@code axes} metadata order (e.g.
+	 * metadata axes=[t,c,z,y,x] is reported as data dimensions=[x,y,z,c,t]) - and the
+	 * same reversal applies to the per-axis {@code scale}/{@code translation} arrays in
+	 * the coordinateTransformations metadata (see {@link #getMipMapResolutions}).
+	 * Producers that declare a different (but equally NGFF-valid) axes order - e.g.
+	 * axes=[x,y,z] instead of [z,y,x] - would otherwise have X and Z silently swapped by
+	 * callers that assume the standard TCZYX/XYZCT position (0,1,2), which shows up as a
+	 * rotated/transposed volume, or (for scale/translation) a squished/stretched one.
+	 * Look up the x/y/z entries by name instead.
+	 *
+	 * @return {xIndex, yIndex, zIndex} into the raw (reversed) per-axis array, or
+	 *         {@code null} if the axes metadata is missing or does not name all three
+	 *         spatial axes (callers should then assume the standard {0,1,2} order).
+	 */
+	public int[] getRawSpatialAxesIndices( final N5Reader n5, final int setupId, final int timepointId )
+	{
+		return xyzAxesIndices( getViewSetupMultiscaleMetadata( n5, timepointId, setupId ).axes );
+	}
+
+	private static int[] xyzAxesIndices( final Axis[] axes )
+	{
+		if ( axes == null )
+			return null;
+
+		final String[] xyz = { "x", "y", "z" };
+		final int[] idx = { -1, -1, -1 };
+
+		for ( int i = 0; i < axes.length; ++i )
+			for ( int d = 0; d < 3; ++d )
+				if ( xyz[ d ].equalsIgnoreCase( axes[ i ].getName() ) )
+					idx[ d ] = axes.length - 1 - i; // dimensions[]/scale[]/translation[] are axes[] reversed
+
+		return ( idx[ 0 ] < 0 || idx[ 1 ] < 0 || idx[ 2 ] < 0 ) ? null : idx;
 	}
 
 	//
@@ -165,6 +208,12 @@ public class AllenOMEZarrProperties implements N5Properties
 		// final GsonBuilder builder = new GsonBuilder().registerTypeAdapter( CoordinateTransformation.class, new CoordinateTransformationAdapter() );
 		final String path = n5properties.getPath( setupId, timePointId );
 
+		// index of x/y/z within the raw (reversed) scale/translation arrays - see
+		// getRawSpatialAxesIndices(); falls back to the standard TCZYX/XYZCT position
+		// (0,1,2) if the axes metadata is missing or incomplete
+		final int[] xyzIdx = xyzAxesIndices( multiScaleMetadata.axes );
+		final int[] raw = xyzIdx != null ? xyzIdx : new int[] { 0, 1, 2 };
+
 		// iterate over all resolution levels for scale
 		for ( int s = 0; s < multiScaleMetadata.datasets.length; ++s )
 		{
@@ -181,7 +230,7 @@ public class AllenOMEZarrProperties implements N5Properties
 
 					for ( int d = 0; d < mipMapResolutions[ s ].length; ++d )
 					{
-						mipMapResolutions[ s ][ d ] = scale.getScale()[ d ] / scaleS0[ d ];
+						mipMapResolutions[ s ][ d ] = scale.getScale()[ raw[ d ] ] / scaleS0[ raw[ d ] ];
 						mipMapResolutions[ s ][ d ] = Math.round(mipMapResolutions[ s ][ d ]*10000)/10000d; // round to the 5th digit
 					}
 				}
@@ -231,7 +280,7 @@ public class AllenOMEZarrProperties implements N5Properties
 						if ( Math.abs( r - 1.0 ) < 0.01 )
 							continue;
 
-						final double pxTranslation = (t.getTranslation()[d] - translationS0[d]) / scaleS0[d];
+						final double pxTranslation = (t.getTranslation()[ raw[ d ] ] - translationS0[ raw[ d ] ]) / scaleS0[ raw[ d ] ];
                         final double logScale = Math.log( r ) / Math.log(2);
 						final double expectedAveraging = Math.pow(2, logScale - 1) - 0.5; // 0.5, 1.5, 3.5, 7.5, ...
 						final boolean matchesAveraging = Math.abs( pxTranslation - expectedAveraging ) < 0.05;

--- a/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/AllenOMEZarrProperties.java
+++ b/src/main/java/net/preibisch/mvrecon/fiji/spimdata/imgloaders/AllenOMEZarrProperties.java
@@ -153,20 +153,47 @@ public class AllenOMEZarrProperties implements N5Properties
 		return ( idx[ 0 ] < 0 || idx[ 1 ] < 0 || idx[ 2 ] < 0 ) ? null : idx;
 	}
 
-	/**
-	 * Raw (reversed-from-metadata) dimension index of each canonical axis, as
-	 * {@code { xRaw, yRaw, zRaw, cRaw, tRaw }} (x/y/z by name, c/t by type; cRaw/tRaw are -1 when
-	 * that axis is not declared), or {@code null} if the axes metadata does not name all of x,y,z
-	 * (callers then assume the standard XYZCT order).
-	 */
+	/** See {@link #rawAxisIndices(Axis[])}. */
 	public int[] getRawAxisIndices( final N5Reader n5, final int setupId, final int timepointId )
 	{
-		final Axis[] axes = getViewSetupMultiscaleMetadata( n5, timepointId, setupId ).axes;
+		return rawAxisIndices( getViewSetupMultiscaleMetadata( n5, timepointId, setupId ).axes );
+	}
+
+	/**
+	 * Raw (reversed-from-metadata) index of each canonical axis: {@code { xRaw, yRaw, zRaw, cRaw,
+	 * tRaw }}. x/y/z are matched by name; c/t by type, falling back to whichever raw indices x/y/z
+	 * didn't claim (not the fixed positions 3/4, which may already be a spatial axis if axes[]
+	 * isn't in canonical order). cRaw/tRaw are -1 if that axis isn't declared at all. Returns
+	 * {@code null} if x/y/z aren't all named (callers then assume the standard XYZCT order).
+	 */
+	public static int[] rawAxisIndices( final Axis[] axes )
+	{
 		final int[] xyz = xyzAxesIndices( axes );
 		if ( xyz == null )
 			return null;
 
-		return new int[] { xyz[ 0 ], xyz[ 1 ], xyz[ 2 ], rawAxisIndexByType( axes, Axis.CHANNEL ), rawAxisIndexByType( axes, Axis.TIME ) };
+		int cRaw = rawAxisIndexByType( axes, Axis.CHANNEL );
+		int tRaw = rawAxisIndexByType( axes, Axis.TIME );
+
+		if ( cRaw < 0 || tRaw < 0 )
+		{
+			final boolean[] claimed = new boolean[ axes.length ];
+			claimed[ xyz[ 0 ] ] = claimed[ xyz[ 1 ] ] = claimed[ xyz[ 2 ] ] = true;
+			if ( cRaw >= 0 ) claimed[ cRaw ] = true;
+			if ( tRaw >= 0 ) claimed[ tRaw ] = true;
+
+			for ( int r = 0; r < axes.length && ( cRaw < 0 || tRaw < 0 ); ++r )
+			{
+				if ( claimed[ r ] )
+					continue;
+				if ( cRaw < 0 )
+					cRaw = r;
+				else
+					tRaw = r;
+			}
+		}
+
+		return new int[] { xyz[ 0 ], xyz[ 1 ], xyz[ 2 ], cRaw, tRaw };
 	}
 
 	/**


### PR DESCRIPTION
Previously, zarr data axis order was always presumed to be in (T)(C)ZYX format. This is not necessarily the case, as zarr axis order is specified in metadata and does not have to be ZYX. This PR reads the metadata to determine the axis order, only falling back to (T)(C)ZYX if axis labels / types cannot be used to infer the order.