### PR TITLE
fix Overlap to require expandOverlap parameter (TODO: remove all old …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,25 +132,20 @@ like Selective Plane Illumination Microscopy (SPIM) Data.</description>
 		<n5-zstandard.version>2.0.0</n5-zstandard.version>
 	</properties>
 
-	<!--
 	<repositories>
 		<repository>
 			<id>scijava.public</id>
 			<url>https://maven.scijava.org/content/groups/public</url>
 		</repository>
-	</repositories>
-	-->
-
-	<repositories>
+		<!--
+		  Bio-Formats (ome:*) artifacts are only proxied by maven.scijava.org, so builds break
+		  whenever that proxy is unavailable (as it has been since the August 2026 outage, see
+		  https://forum.image.sc/t/maven-scijava-org-unavailable/120874 ).
+		  Pulling them from the upstream OME repository removes that dependency on the proxy.
+		-->
 		<repository>
-		<id>scijava.public</id>
-			<url>https://maven.scijava.org/content/groups/public</url>
-			<releases><checksumPolicy>fail</checksumPolicy></releases>
-			<snapshots><checksumPolicy>fail</checksumPolicy></snapshots>
-		</repository>
-		<repository>
-			<id>ome</id>
-			<url>https://artifacts.openmicroscopy.org/artifactory/maven</url>
+			<id>ome.releases</id>
+			<url>https://artifacts.openmicroscopy.org/artifactory/ome.releases</url>
 		</repository>
 	</repositories>
 

--- a/src/main/java/net/preibisch/mvrecon/process/fusion/blk/BlkThinPlateSplineFusion.java
+++ b/src/main/java/net/preibisch/mvrecon/process/fusion/blk/BlkThinPlateSplineFusion.java
@@ -48,7 +48,6 @@ import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.RealLocalizable;
-import net.imglib2.RealPoint;
 import net.imglib2.RealPositionable;
 import net.imglib2.algorithm.blocks.BlockSupplier;
 import net.imglib2.algorithm.blocks.convert.Convert;
@@ -60,10 +59,10 @@ import net.imglib2.algorithm.blocks.transform.Transform.Interpolation;
 import net.imglib2.converter.Converter;
 import net.imglib2.realtransform.AffineGet;
 import net.imglib2.realtransform.AffineTransform3D;
-import net.imglib2.realtransform.InvertibleRealTransform;
 import net.imglib2.realtransform.RealTransform;
 import net.imglib2.realtransform.ThinplateSplineTransform;
 import net.imglib2.realtransform.interval.IntervalSamplingMethod;
+import net.imglib2.realtransform.inverse.InverseRealTransformGradientDescent;
 import net.imglib2.realtransform.inverse.WrappedIterativeInvertibleRealTransform;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
@@ -75,6 +74,7 @@ import net.imglib2.util.ConstantUtils;
 import net.imglib2.util.Intervals;
 import net.imglib2.util.Util;
 import net.imglib2.view.Views;
+import net.preibisch.legacy.io.IOFunctions;
 import net.preibisch.mvrecon.fiji.plugin.fusion.FusionGUI.FusionType;
 import net.preibisch.mvrecon.process.fusion.FusionTools;
 import net.preibisch.mvrecon.process.fusion.blk.tps.BlendingFunction3D;
@@ -168,7 +168,8 @@ public class BlkThinPlateSplineFusion
 					// we go from output to input
 					landmarks.getTargetPoints(), landmarks.getSourcePoints() );
 			final Dimensions dims = viewDimensions.get( viewId );
-			viewBounds.put( viewId, inverseTransformedBoundingBox( tps, approximateAffines.get( viewId ).inverse(), dims ) );
+			// the approximate affine maps image -> render, i.e. it approximates the *inverse* TPS
+			viewBounds.put( viewId, inverseTransformedBoundingBox( tps, approximateAffines.get( viewId ), dims ) );
 		}
 
 		// Sample the dfield (eager ArrayImg allocation) only for views that overlap
@@ -202,7 +203,7 @@ public class BlkThinPlateSplineFusion
 	 *
 	 * @param viewBounds
 	 * 		back-projected bounding box (render coordinates) per view, as
-	 * 		produced by {@link #inverseTransformedBoundingBox(ThinplateSplineTransform, Dimensions)}.
+	 * 		produced by {@link #inverseTransformedBoundingBox(ThinplateSplineTransform, RealTransform, Dimensions)}.
 	 * @param rawDfields
 	 * 		un-offset displacement fields per view, as produced by
 	 * 		{@code DisplacementFields.sample(tps, viewBounds.get(viewId), spacing)}.
@@ -439,6 +440,7 @@ public class BlkThinPlateSplineFusion
 		} catch (NotEnoughDataPointsException | IllDefinedDataPointsException e)
 		{
 			e.printStackTrace();
+			throw new RuntimeException( e );
 		}
 
 		final double[][] mm = new double[ 3 ][ 4 ];
@@ -458,11 +460,30 @@ public class BlkThinPlateSplineFusion
 	 * Get the bounding box in render coordinates of an image of the given
 	 * {@code dimension} when back-projected through the inverse of the given
 	 * {@code transform} from rendered to image coordinates.
+	 * <p>
+	 * The inverse is imglib2's iterative {@link InverseRealTransformGradientDescent}.
+	 * Its {@code apply(s, t)} is implemented as {@code inverseTol(s, s, ...)}, i.e. the
+	 * descent is seeded with the query point itself: an image coordinate, while the
+	 * answer is a render coordinate that can be tens of thousands of pixels away. From
+	 * there the descent converges onto a spurious preimage, and the resulting bogus box
+	 * silently drops the view from every block it should have contributed to.
+	 * {@code setGuess} is a deprecated no-op, so the only way to provide a seed is to
+	 * call {@code inverseTol(target, guess, ...)} directly. That is what
+	 * {@link GuessingRealTransform} does, using {@code invGuess} (the per-view
+	 * approximate affine) to compute the seed for every corner.
+	 * <p>
+	 * A TPS from few landmarks is non-injective where the corners extrapolate, so a
+	 * converged corner is not always the right one. A corner is used only if it
+	 * converged and stayed within {@code max(dimensions)} of the guess; otherwise the
+	 * guess itself is used.
 	 *
 	 * @param transform
 	 * 		forward transform (from rendered to image coordinates)
 	 * @param invGuess
-	 * 		a guess of the inverse TPS to better initialize InverseRealTransformGradientDescent
+	 * 		approximation of the <em>inverse</em> transform (from image to render
+	 * 		coordinates), e.g. the affine from {@link #fitAffineTransform}. Seeds the
+	 * 		iterative inverse at each corner and is the fallback for corners that fail
+	 * 		the checks above.
 	 * @param dimensions
 	 * 		image dimensions
 	 *
@@ -470,62 +491,189 @@ public class BlkThinPlateSplineFusion
 	 */
 	public static Interval inverseTransformedBoundingBox(
 			final ThinplateSplineTransform transform,
-			final RealTransform /*AffineGet*/ invGuess,
+			final RealTransform invGuess,
 			final Dimensions dimensions )
 	{
-		// transforms from source img pixels to render coordinates
-		final RealTransform invTransform = new WrappedIterativeInvertibleRealTransform<>( transform ).inverse();
+		// A corner cannot be further from the guess than the image is wide; beyond
+		// that it is a different branch of the inverse. Measured: real deviations
+		// reach ~266px on a ~4100px tile, wrong-branch ones start at ~46000px.
+		double maxDeviation = 0;
+		for ( int d = 0; d < dimensions.numDimensions(); ++d )
+			maxDeviation = Math.max( maxDeviation, dimensions.dimension( d ) );
 
-		final RealTransform invTransformGuess = new GuessingRealTransform( invTransform, invGuess );
+		// transforms from source img pixels to render coordinates, seeded with invGuess
+		final GuessingRealTransform invTransform = new GuessingRealTransform(
+				new WrappedIterativeInvertibleRealTransform<>( transform ), invGuess, maxDeviation );
 
 		// estimated bounding box of the source img transformed to render coordinates
-		return Intervals.smallestContainingInterval(
-				invTransformGuess.boundingInterval(
+		final Interval bb = Intervals.smallestContainingInterval(
+				invTransform.boundingInterval(
 						new FinalInterval( dimensions ),
 						IntervalSamplingMethod.CORNERS ) );
+
+		if ( invTransform.numFallbacks() > 0 )
+			IOFunctions.println( "[TPS] inverseTransformedBoundingBox: " + invTransform.numFallbacks() + " of "
+					+ invTransform.numApplied() + " corner(s) did not yield a trustworthy inverse; "
+					+ "used the approximate affine for those." );
+
+		return bb;
 	}
 
 	/**
-	 * We need this so the InverseRealTransformGradientDescent can take a guess.
-	 * Measured: real deviations reach ~266px on a ~4100px tile, wrong-branch ones start at ~46000px.
+	 * The inverse of an iteratively invertible transform (e.g. a TPS), where every
+	 * inversion is seeded with a guess computed by a second transform instead of with
+	 * the query point itself.
+	 * <p>
+	 * For a point {@code p}, {@link #apply} computes {@code guess = invGuess(p)} and then
+	 * runs {@link InverseRealTransformGradientDescent#inverseTol(double[], double[], double, int)
+	 * inverseTol(p, guess, tolerance, maxIters)}: the descent solves {@code forward(x) = p}
+	 * starting at {@code guess}. Note that this is <em>not</em> the same as composing
+	 * {@code invGuess} with {@code WrappedIterativeInvertibleRealTransform.inverse()}.
+	 * That would end up in {@code inverseTol(guess, guess, ...)} and solve
+	 * {@code forward(x) = guess}, i.e. invert a different point, still seeded with itself.
+	 * <p>
+	 * The solution is used only if the descent converged ({@code error < tolerance}) and
+	 * it lies within {@code maxDeviation} (per dimension) of the guess; otherwise the
+	 * guess itself is returned and {@link #numFallbacks()} is incremented.
+	 * <p>
+	 * Not thread-safe (the underlying optimizer is stateful); use {@link #copy()} per thread.
 	 */
 	public static class GuessingRealTransform implements RealTransform
 	{
-		final RealTransform invTransform, invGuess;
-		
+		// imglib2's InverseRealTransformGradientDescent defaults, on purpose. A wider
+		// backtracking range (beta, stepSizeMaxTries) converges more corners but lets the
+		// descent reach the spurious preimages, which moved measured boxes by tens of
+		// thousands of pixels.
+		public static final double DEFAULT_TOLERANCE = 0.5;
+
+		public static final int DEFAULT_MAX_ITERS = 100;
+
+		private final WrappedIterativeInvertibleRealTransform< ? > forward;
+
+		private final InverseRealTransformGradientDescent optimizer;
+
+		private final RealTransform invGuess;
+
+		private final double maxDeviation;
+
+		private final double tolerance;
+
+		private final int maxIters;
+
+		private final int n;
+
+		private final double[] guess;
+
+		private final double[] tmpSource;
+
+		private final double[] tmpTarget;
+
+		private int numApplied = 0;
+
+		private int numFallbacks = 0;
+
+		/**
+		 * @param forward
+		 * 		the (wrapped) forward transform to invert
+		 * @param invGuess
+		 * 		approximation of the inverse of {@code forward}; provides the seed and the fallback
+		 * @param maxDeviation
+		 * 		a solution further than this (in any dimension) from the guess is rejected
+		 */
 		public GuessingRealTransform(
-				final RealTransform /*WrappedIterativeInvertibleRealTransform*/ invTransform,
-				final RealTransform /*AffineGet*/ invGuess )
+				final WrappedIterativeInvertibleRealTransform< ? > forward,
+				final RealTransform invGuess,
+				final double maxDeviation )
 		{
-			this.invTransform = invTransform;
+			this( forward, invGuess, maxDeviation, DEFAULT_TOLERANCE, DEFAULT_MAX_ITERS );
+		}
+
+		public GuessingRealTransform(
+				final WrappedIterativeInvertibleRealTransform< ? > forward,
+				final RealTransform invGuess,
+				final double maxDeviation,
+				final double tolerance,
+				final int maxIters )
+		{
+			n = forward.numSourceDimensions();
+			if ( forward.numTargetDimensions() != n )
+				throw new IllegalArgumentException( "iterative inversion requires numSourceDimensions == numTargetDimensions" );
+			if ( invGuess.numSourceDimensions() != n || invGuess.numTargetDimensions() != n )
+				throw new IllegalArgumentException( "invGuess dimensionality does not match the forward transform" );
+
+			this.forward = forward;
+			this.optimizer = forward.getOptimzer();
 			this.invGuess = invGuess;
+			this.maxDeviation = maxDeviation;
+			this.tolerance = tolerance;
+			this.maxIters = maxIters;
+
+			guess = new double[ n ];
+			tmpSource = new double[ n ];
+			tmpTarget = new double[ n ];
+		}
+
+		/** @return number of points inverted so far */
+		public int numApplied()
+		{
+			return numApplied;
+		}
+
+		/** @return number of points for which the guess was returned instead of the descent result */
+		public int numFallbacks()
+		{
+			return numFallbacks;
 		}
 
 		@Override
-		public int numSourceDimensions() { return invTransform.numSourceDimensions(); }
-
-		@Override
-		public int numTargetDimensions() {  return invTransform.numTargetDimensions(); }
-
-		@Override
-		public void apply(double[] source, double[] target)
+		public int numSourceDimensions()
 		{
-			invGuess.apply( source, source );
-			invTransform.apply( source, target );
+			return forward.numTargetDimensions();
 		}
 
 		@Override
-		public void apply( RealLocalizable source, RealPositionable target )
+		public int numTargetDimensions()
 		{
-			final RealPoint p = new RealPoint( source );
-			invGuess.apply( p, p );
-			invTransform.apply( p, target);
+			return forward.numSourceDimensions();
 		}
 
 		@Override
-		public RealTransform copy()
+		public void apply( final double[] source, final double[] target )
 		{
-			return new GuessingRealTransform( invTransform, invGuess );
+			// seed: where the guess transform puts this point
+			invGuess.apply( source, guess );
+
+			// solve forward(x) = source, starting at guess. inverseTol copies the guess but
+			// keeps a reference to its target argument, so hand it source directly (source
+			// is not modified here) and read the estimate before touching target.
+			final double error = optimizer.inverseTol( source, guess, tolerance, maxIters );
+			final double[] estimate = optimizer.getEstimate();
+
+			double deviation = 0;
+			for ( int d = 0; d < n; ++d )
+				deviation = Math.max( deviation, Math.abs( estimate[ d ] - guess[ d ] ) );
+
+			final boolean trust = error < tolerance && deviation <= maxDeviation;
+			++numApplied;
+			if ( !trust )
+				++numFallbacks;
+
+			// write last: source and target may be the same array (Corners.bounds calls apply(pt, pt))
+			System.arraycopy( trust ? estimate : guess, 0, target, 0, n );
+		}
+
+		@Override
+		public void apply( final RealLocalizable source, final RealPositionable target )
+		{
+			source.localize( tmpSource );
+			apply( tmpSource, tmpTarget );
+			target.setPosition( tmpTarget );
+		}
+
+		@Override
+		public GuessingRealTransform copy()
+		{
+			return new GuessingRealTransform( forward.copy(), invGuess.copy(), maxDeviation, tolerance, maxIters );
 		}
 	}
 }

--- a/src/main/java/net/preibisch/mvrecon/process/fusion/blk/BlkThinPlateSplineFusion.java
+++ b/src/main/java/net/preibisch/mvrecon/process/fusion/blk/BlkThinPlateSplineFusion.java
@@ -476,7 +476,7 @@ public class BlkThinPlateSplineFusion
 		// transforms from source img pixels to render coordinates
 		final RealTransform invTransform = new WrappedIterativeInvertibleRealTransform<>( transform ).inverse();
 
-		final RealTransform invTransformGuess = new GuessingRealTransform( invTransform, invTransform );
+		final RealTransform invTransformGuess = new GuessingRealTransform( invTransform, invGuess );
 
 		// estimated bounding box of the source img transformed to render coordinates
 		return Intervals.smallestContainingInterval(

--- a/src/main/java/net/preibisch/mvrecon/process/fusion/blk/BlkThinPlateSplineFusion.java
+++ b/src/main/java/net/preibisch/mvrecon/process/fusion/blk/BlkThinPlateSplineFusion.java
@@ -147,29 +147,20 @@ public class BlkThinPlateSplineFusion
 		final List< ? extends ViewId > sortedViewIds = new ArrayList<>( viewIds );
 		sortedViewIds.sort( fusionOrder != null ? fusionOrder : Comparator.naturalOrder() );
 
-		// Pre-fit per-view approximate affines from the landmarks (used downstream for initialization
-		// for inverting the TPS transforms, as well as blending-weight adjustment). Done once here so
-		// initWithLoadedDfields no longer needs the full landmark map and can be driven from a cached-affines
-		// container instead.
+		// Per view: TPS (render -> image), approximate affine (image -> render) and the
+		// back-projected bounding box (render coordinates). The affines seed the iterative
+		// TPS inverse for the bounding boxes and are used downstream for blending-weight
+		// adjustment. Done once here so initWithLoadedDfields no longer needs the full
+		// landmark map and can be driven from a cached-affines container instead.
+		final Map< ViewId, ThinplateSplineTransform > tpsMap = new HashMap<>();
 		final Map< ViewId, AffineTransform3D > approximateAffines = new HashMap<>();
-		for ( final ViewId viewId : sortedViewIds )
-		{
-			final Landmarks landmarks = viewLandmarks.get( viewId );
-			approximateAffines.put( viewId,
-					fitAffineTransform( landmarks.getSourcePoints(), landmarks.getTargetPoints() ) );
-		}
-
-		// back-projected bounding box (render coordinates) for every underlying view
 		final Map< ViewId, Interval > viewBounds = new HashMap<>();
 		for ( final ViewId viewId : sortedViewIds )
 		{
-			final Landmarks landmarks = viewLandmarks.get( viewId );
-			final ThinplateSplineTransform tps = new ThinplateSplineTransform(
-					// we go from output to input
-					landmarks.getTargetPoints(), landmarks.getSourcePoints() );
-			final Dimensions dims = viewDimensions.get( viewId );
-			// the approximate affine maps image -> render, i.e. it approximates the *inverse* TPS
-			viewBounds.put( viewId, inverseTransformedBoundingBox( tps, approximateAffines.get( viewId ), dims ) );
+			final TpsSetup setup = setupTps( viewLandmarks.get( viewId ), viewDimensions.get( viewId ) );
+			tpsMap.put( viewId, setup.tps );
+			approximateAffines.put( viewId, setup.approximateAffine );
+			viewBounds.put( viewId, setup.boundingBox );
 		}
 
 		// Sample the dfield (eager ArrayImg allocation) only for views that overlap
@@ -178,12 +169,7 @@ public class BlkThinPlateSplineFusion
 		final Overlap preFilterOverlap = new Overlap( sortedViewIds, viewBounds, defaultIntervalExpansion, 3 ).filter( fusionInterval );
 		final Map< ViewId, TransformedDisplacementField< DoubleType > > rawDfields = new HashMap<>();
 		for ( final ViewId viewId : preFilterOverlap.getViewIds() )
-		{
-			final Landmarks landmarks = viewLandmarks.get( viewId );
-			final ThinplateSplineTransform tps = new ThinplateSplineTransform(
-					landmarks.getTargetPoints(), landmarks.getSourcePoints() );
-			rawDfields.put( viewId, DisplacementFields.sample( tps, viewBounds.get( viewId ), spacing ) );
-		}
+			rawDfields.put( viewId, DisplacementFields.sample( tpsMap.get( viewId ), viewBounds.get( viewId ), spacing ) );
 
 		return initWithLoadedDfields(
 				converter, imgLoader, viewIds, viewDescriptions, approximateAffines,
@@ -203,7 +189,8 @@ public class BlkThinPlateSplineFusion
 	 *
 	 * @param viewBounds
 	 * 		back-projected bounding box (render coordinates) per view, as
-	 * 		produced by {@link #inverseTransformedBoundingBox(ThinplateSplineTransform, RealTransform, Dimensions)}.
+	 * 		produced by {@link #setupTps(Landmarks, Dimensions)} (i.e. by
+	 * 		{@link #inverseTransformedBoundingBox(ThinplateSplineTransform, RealTransform, Dimensions)}).
 	 * @param rawDfields
 	 * 		un-offset displacement fields per view, as produced by
 	 * 		{@code DisplacementFields.sample(tps, viewBounds.get(viewId), spacing)}.
@@ -454,6 +441,64 @@ public class BlkThinPlateSplineFusion
 				mm[2][0], mm[2][1], mm[2][2], mm[2][3] );
 
 		return t;
+	}
+
+	/**
+	 * Everything fusion needs up front from one view's landmarks: the forward TPS
+	 * (render to image coordinates), the affine approximating its inverse (image to
+	 * render coordinates) and the back-projected bounding box in render coordinates.
+	 * <p>
+	 * Create instances with {@link #setupTps(Landmarks, Dimensions)}, so that all callers
+	 * (the local {@link #init init} and the Spark displacement-field cache) agree on the
+	 * transform directions and on seeding the iterative TPS inverse.
+	 */
+	public static final class TpsSetup
+	{
+		/** forward transform, from render to image coordinates */
+		public final ThinplateSplineTransform tps;
+
+		/** affine approximation of the <em>inverse</em> TPS, from image to render coordinates */
+		public final AffineTransform3D approximateAffine;
+
+		/** bounding box of the image in render coordinates */
+		public final Interval boundingBox;
+
+		TpsSetup( final ThinplateSplineTransform tps, final AffineTransform3D approximateAffine, final Interval boundingBox )
+		{
+			this.tps = tps;
+			this.approximateAffine = approximateAffine;
+			this.boundingBox = boundingBox;
+		}
+	}
+
+	/**
+	 * Build the per-view transforms from landmarks: the TPS from the landmark target
+	 * points (render coordinates) to the source points (image coordinates), the affine
+	 * fitted the other way round (image to render, see {@link #fitAffineTransform}), and
+	 * the bounding box of the image in render coordinates from
+	 * {@link #inverseTransformedBoundingBox(ThinplateSplineTransform, RealTransform, Dimensions)},
+	 * with the affine seeding the iterative TPS inverse.
+	 *
+	 * @param landmarks
+	 * 		source (image) and target (render) landmark coordinates of the view
+	 * @param dimensions
+	 * 		image dimensions of the view
+	 *
+	 * @return TPS, approximate affine and bounding box
+	 */
+	public static TpsSetup setupTps( final Landmarks landmarks, final Dimensions dimensions )
+	{
+		// we go from output to input
+		final ThinplateSplineTransform tps = new ThinplateSplineTransform(
+				landmarks.getTargetPoints(), landmarks.getSourcePoints() );
+
+		// the approximate affine maps image -> render, i.e. it approximates the *inverse* TPS
+		final AffineTransform3D approximateAffine = fitAffineTransform(
+				landmarks.getSourcePoints(), landmarks.getTargetPoints() );
+
+		final Interval boundingBox = inverseTransformedBoundingBox( tps, approximateAffine, dimensions );
+
+		return new TpsSetup( tps, approximateAffine, boundingBox );
 	}
 
 	/**

--- a/src/main/java/net/preibisch/mvrecon/process/fusion/blk/BlkThinPlateSplineFusion.java
+++ b/src/main/java/net/preibisch/mvrecon/process/fusion/blk/BlkThinPlateSplineFusion.java
@@ -47,6 +47,9 @@ import net.imglib2.Dimensions;
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RealLocalizable;
+import net.imglib2.RealPoint;
+import net.imglib2.RealPositionable;
 import net.imglib2.algorithm.blocks.BlockSupplier;
 import net.imglib2.algorithm.blocks.convert.Convert;
 import net.imglib2.algorithm.blocks.dfield.DisplacementField;
@@ -57,6 +60,7 @@ import net.imglib2.algorithm.blocks.transform.Transform.Interpolation;
 import net.imglib2.converter.Converter;
 import net.imglib2.realtransform.AffineGet;
 import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.realtransform.InvertibleRealTransform;
 import net.imglib2.realtransform.RealTransform;
 import net.imglib2.realtransform.ThinplateSplineTransform;
 import net.imglib2.realtransform.interval.IntervalSamplingMethod;
@@ -143,6 +147,18 @@ public class BlkThinPlateSplineFusion
 		final List< ? extends ViewId > sortedViewIds = new ArrayList<>( viewIds );
 		sortedViewIds.sort( fusionOrder != null ? fusionOrder : Comparator.naturalOrder() );
 
+		// Pre-fit per-view approximate affines from the landmarks (used downstream for initialization
+		// for inverting the TPS transforms, as well as blending-weight adjustment). Done once here so
+		// initWithLoadedDfields no longer needs the full landmark map and can be driven from a cached-affines
+		// container instead.
+		final Map< ViewId, AffineTransform3D > approximateAffines = new HashMap<>();
+		for ( final ViewId viewId : sortedViewIds )
+		{
+			final Landmarks landmarks = viewLandmarks.get( viewId );
+			approximateAffines.put( viewId,
+					fitAffineTransform( landmarks.getSourcePoints(), landmarks.getTargetPoints() ) );
+		}
+
 		// back-projected bounding box (render coordinates) for every underlying view
 		final Map< ViewId, Interval > viewBounds = new HashMap<>();
 		for ( final ViewId viewId : sortedViewIds )
@@ -152,13 +168,13 @@ public class BlkThinPlateSplineFusion
 					// we go from output to input
 					landmarks.getTargetPoints(), landmarks.getSourcePoints() );
 			final Dimensions dims = viewDimensions.get( viewId );
-			viewBounds.put( viewId, inverseTransformedBoundingBox( tps, dims ) );
+			viewBounds.put( viewId, inverseTransformedBoundingBox( tps, approximateAffines.get( viewId ).inverse(), dims ) );
 		}
 
 		// Sample the dfield (eager ArrayImg allocation) only for views that overlap
 		// the fusionInterval. This preserves the historical optimization where
 		// non-overlapping views never trigger a TPS rasterization.
-		final Overlap preFilterOverlap = new Overlap( sortedViewIds, viewBounds, 3 ).filter( fusionInterval );
+		final Overlap preFilterOverlap = new Overlap( sortedViewIds, viewBounds, defaultIntervalExpansion, 3 ).filter( fusionInterval );
 		final Map< ViewId, TransformedDisplacementField< DoubleType > > rawDfields = new HashMap<>();
 		for ( final ViewId viewId : preFilterOverlap.getViewIds() )
 		{
@@ -166,17 +182,6 @@ public class BlkThinPlateSplineFusion
 			final ThinplateSplineTransform tps = new ThinplateSplineTransform(
 					landmarks.getTargetPoints(), landmarks.getSourcePoints() );
 			rawDfields.put( viewId, DisplacementFields.sample( tps, viewBounds.get( viewId ), spacing ) );
-		}
-
-		// Pre-fit per-view approximate affines from the landmarks (used downstream only for
-		// blending-weight adjustment). Done once here so initWithLoadedDfields no longer needs
-		// the full landmark map and can be driven from a cached-affines container instead.
-		final Map< ViewId, AffineTransform3D > approximateAffines = new HashMap<>();
-		for ( final ViewId viewId : sortedViewIds )
-		{
-			final Landmarks landmarks = viewLandmarks.get( viewId );
-			approximateAffines.put( viewId,
-					fitAffineTransform( landmarks.getSourcePoints(), landmarks.getTargetPoints() ) );
 		}
 
 		return initWithLoadedDfields(
@@ -230,7 +235,7 @@ public class BlkThinPlateSplineFusion
 		// Which views to process (use un-altered bounding box and registrations).
 		// Final filtering happens per Cell. Here we just pre-filter everything
 		// outside the fusionInterval.
-		final Overlap overlap = new Overlap( sortedViewIds, viewBounds, 3 )
+		final Overlap overlap = new Overlap( sortedViewIds, viewBounds, defaultIntervalExpansion, 3 )
 				.filter( fusionInterval )
 				.offset( fusionInterval.minAsLongArray() );
 
@@ -456,6 +461,8 @@ public class BlkThinPlateSplineFusion
 	 *
 	 * @param transform
 	 * 		forward transform (from rendered to image coordinates)
+	 * @param invGuess
+	 * 		a guess of the inverse TPS to better initialize InverseRealTransformGradientDescent
 	 * @param dimensions
 	 * 		image dimensions
 	 *
@@ -463,15 +470,62 @@ public class BlkThinPlateSplineFusion
 	 */
 	public static Interval inverseTransformedBoundingBox(
 			final ThinplateSplineTransform transform,
+			final RealTransform /*AffineGet*/ invGuess,
 			final Dimensions dimensions )
 	{
 		// transforms from source img pixels to render coordinates
 		final RealTransform invTransform = new WrappedIterativeInvertibleRealTransform<>( transform ).inverse();
 
+		final RealTransform invTransformGuess = new GuessingRealTransform( invTransform, invTransform );
+
 		// estimated bounding box of the source img transformed to render coordinates
 		return Intervals.smallestContainingInterval(
-				invTransform.boundingInterval(
+				invTransformGuess.boundingInterval(
 						new FinalInterval( dimensions ),
 						IntervalSamplingMethod.CORNERS ) );
+	}
+
+	/**
+	 * We need this so the InverseRealTransformGradientDescent can take a guess.
+	 * Measured: real deviations reach ~266px on a ~4100px tile, wrong-branch ones start at ~46000px.
+	 */
+	public static class GuessingRealTransform implements RealTransform
+	{
+		final RealTransform invTransform, invGuess;
+		
+		public GuessingRealTransform(
+				final RealTransform /*WrappedIterativeInvertibleRealTransform*/ invTransform,
+				final RealTransform /*AffineGet*/ invGuess )
+		{
+			this.invTransform = invTransform;
+			this.invGuess = invGuess;
+		}
+
+		@Override
+		public int numSourceDimensions() { return invTransform.numSourceDimensions(); }
+
+		@Override
+		public int numTargetDimensions() {  return invTransform.numTargetDimensions(); }
+
+		@Override
+		public void apply(double[] source, double[] target)
+		{
+			invGuess.apply( source, source );
+			invTransform.apply( source, target );
+		}
+
+		@Override
+		public void apply( RealLocalizable source, RealPositionable target )
+		{
+			final RealPoint p = new RealPoint( source );
+			invGuess.apply( p, p );
+			invTransform.apply( p, target);
+		}
+
+		@Override
+		public RealTransform copy()
+		{
+			return new GuessingRealTransform( invTransform, invGuess );
+		}
 	}
 }

--- a/src/main/java/net/preibisch/mvrecon/process/fusion/blk/Overlap.java
+++ b/src/main/java/net/preibisch/mvrecon/process/fusion/blk/Overlap.java
@@ -57,6 +57,7 @@ class Overlap
 	public Overlap(
 			final List< ? extends ViewId > viewIds,
 			final Map< ? extends ViewId, ? extends Interval > viewBounds,
+			final int expandOverlap,
 			final int numDimensions )
 	{
 		this.viewIds = viewIds;
@@ -64,7 +65,7 @@ class Overlap
 		numViews = viewIds.size();
 		bb = new long[ numViews * numDimensions * 2 ];
 		for ( int i = 0; i < numViews; ++i )
-			setBounds( i, viewBounds.get( viewIds.get( i ) ) );
+			setBounds( i, Intervals.expand( viewBounds.get( viewIds.get( i ) ), expandOverlap ) );
 	}
 
 	public Overlap(

--- a/src/test/java/net/preibisch/mvrecon/process/fusion/blk/InverseTransformedBoundingBoxTest.java
+++ b/src/test/java/net/preibisch/mvrecon/process/fusion/blk/InverseTransformedBoundingBoxTest.java
@@ -1,0 +1,299 @@
+/*-
+ * #%L
+ * Software for the reconstruction of multi-view microscopic acquisitions
+ * like Selective Plane Illumination Microscopy (SPIM) Data.
+ * %%
+ * Copyright (C) 2012 - 2026 Multiview Reconstruction developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+package net.preibisch.mvrecon.process.fusion.blk;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+import net.imglib2.FinalDimensions;
+import net.imglib2.FinalInterval;
+import net.imglib2.Interval;
+import net.imglib2.RealInterval;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.realtransform.RealTransform;
+import net.imglib2.realtransform.ThinplateSplineTransform;
+import net.imglib2.realtransform.interval.IntervalSamplingMethod;
+import net.imglib2.realtransform.inverse.WrappedIterativeInvertibleRealTransform;
+import net.imglib2.util.Intervals;
+import net.preibisch.mvrecon.process.fusion.blk.BlkThinPlateSplineFusion.GuessingRealTransform;
+
+/**
+ * Regression test for {@link BlkThinPlateSplineFusion#inverseTransformedBoundingBox}.
+ * <p>
+ * Simulates an underlying view whose render position is tens of thousands of pixels
+ * away from its local pixel coordinates (a tile in a large stitched volume), with
+ * landmarks in the same {@code [d][i]} layout and the same source/target convention as
+ * {@code Landmarks}: source = image pixel coordinates, target = render coordinates.
+ * <p>
+ * imglib2's iterative inverse seeds each inversion with the query point itself. For a
+ * far-away tile with only a few landmarks (e.g. the split-tile centers) the descent
+ * then never reaches the true preimage. Seeding with the approximate affine fixes that.
+ */
+public class InverseTransformedBoundingBoxTest
+{
+	private static final long[] DIMS = { 4096, 4096, 512 };
+
+	private static final FinalInterval IMAGE = new FinalInterval( DIMS );
+
+	/** image -> render: anisotropic z, slight rotation about z, far translation */
+	private static AffineTransform3D groundTruthAffine()
+	{
+		final AffineTransform3D a = new AffineTransform3D();
+		a.set( 2.0, 2, 2 ); // z anisotropy
+		a.rotate( 2, Math.toRadians( 3 ) );
+		a.translate( 40000, 30000, 2000 );
+		return a;
+	}
+
+	/** smooth, small non-affine displacement (render space) so the TPS is not exactly affine */
+	private static void perturb( final double[] p, final double[] out )
+	{
+		// read first: p and out may be the same array
+		final double x = p[ 0 ], y = p[ 1 ], z = p[ 2 ];
+		out[ 0 ] = x + 4 * Math.sin( y / 1500.0 );
+		out[ 1 ] = y + 3 * Math.cos( x / 2000.0 );
+		out[ 2 ] = z + 2 * Math.sin( ( x + y ) / 3000.0 );
+	}
+
+	private static double[][][] pack( final List< double[] > src, final List< double[] > tgt )
+	{
+		final double[][] source = new double[ 3 ][ src.size() ];
+		final double[][] target = new double[ 3 ][ src.size() ];
+		for ( int i = 0; i < src.size(); ++i )
+			for ( int d = 0; d < 3; ++d )
+			{
+				source[ d ][ i ] = src.get( i )[ d ];
+				target[ d ][ i ] = tgt.get( i )[ d ];
+			}
+		return new double[][][] { source, target };
+	}
+
+	/**
+	 * Dense landmarks: the 8 image corners plus an interior grid, smoothly perturbed.
+	 * Because the TPS interpolates landmarks exactly, the true render preimage of every
+	 * image corner is known exactly here (see {@link #denseExpectedBounds()}).
+	 */
+	private static double[][][] denseLandmarksWithCorners()
+	{
+		final AffineTransform3D gt = groundTruthAffine();
+		final List< double[] > src = new ArrayList<>();
+		final List< double[] > tgt = new ArrayList<>();
+		final double[] fractions = { 0.0, 0.33, 0.66, 1.0 };
+		for ( final double fx : fractions )
+			for ( final double fy : fractions )
+				for ( final double fz : new double[] { 0.0, 0.5, 1.0 } )
+				{
+					final double[] s = { fx * ( DIMS[ 0 ] - 1 ), fy * ( DIMS[ 1 ] - 1 ), fz * ( DIMS[ 2 ] - 1 ) };
+					final double[] t = new double[ 3 ];
+					gt.apply( s, t );
+					perturb( t, t );
+					src.add( s );
+					tgt.add( t );
+				}
+		return pack( src, tgt );
+	}
+
+	private static RealInterval denseExpectedBounds()
+	{
+		final AffineTransform3D gt = groundTruthAffine();
+		final double[] min = { Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY };
+		final double[] max = { Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY };
+		for ( int c = 0; c < 8; ++c )
+		{
+			final double[] t = new double[ 3 ];
+			gt.apply( corner( c ), t );
+			perturb( t, t );
+			for ( int d = 0; d < 3; ++d )
+			{
+				min[ d ] = Math.min( min[ d ], t[ d ] );
+				max[ d ] = Math.max( max[ d ], t[ d ] );
+			}
+		}
+		return Intervals.createMinMaxReal( min[ 0 ], min[ 1 ], min[ 2 ], max[ 0 ], max[ 1 ], max[ 2 ] );
+	}
+
+	/**
+	 * Sparse landmarks: only the 8 centers of a 2x2x2 split (at 25% / 75% of each
+	 * dimension), randomly perturbed by up to {@code amp} px. No landmark is anywhere
+	 * near a corner, so all 8 corners extrapolate. This is the "little split point
+	 * coverage" situation in which the un-seeded inverse fails.
+	 */
+	private static double[][][] sparseSplitCenterLandmarks( final double amp, final long seed )
+	{
+		final AffineTransform3D gt = groundTruthAffine();
+		final Random rnd = new Random( seed );
+		final List< double[] > src = new ArrayList<>();
+		final List< double[] > tgt = new ArrayList<>();
+		for ( final double fx : new double[] { 0.25, 0.75 } )
+			for ( final double fy : new double[] { 0.25, 0.75 } )
+				for ( final double fz : new double[] { 0.25, 0.75 } )
+				{
+					final double[] s = { fx * ( DIMS[ 0 ] - 1 ), fy * ( DIMS[ 1 ] - 1 ), fz * ( DIMS[ 2 ] - 1 ) };
+					final double[] t = new double[ 3 ];
+					gt.apply( s, t );
+					for ( int d = 0; d < 3; ++d )
+						t[ d ] += amp * ( 2 * rnd.nextDouble() - 1 );
+					src.add( s );
+					tgt.add( t );
+				}
+		return pack( src, tgt );
+	}
+
+	private static double[] corner( final int c )
+	{
+		final double[] p = new double[ 3 ];
+		for ( int d = 0; d < 3; ++d )
+			p[ d ] = ( ( c >> d ) & 1 ) == 0 ? 0 : DIMS[ d ] - 1;
+		return p;
+	}
+
+	/** same construction as BlkThinPlateSplineFusion.init(): TPS render -> image */
+	private static ThinplateSplineTransform tps( final double[][][] lm )
+	{
+		return new ThinplateSplineTransform( lm[ 1 ], lm[ 0 ] );
+	}
+
+	/** same construction as BlkThinPlateSplineFusion.init(): approximate affine image -> render */
+	private static AffineTransform3D approxAffine( final double[][][] lm )
+	{
+		return BlkThinPlateSplineFusion.fitAffineTransform( lm[ 0 ], lm[ 1 ] );
+	}
+
+	private static double maxBoundsError( final RealInterval actual, final RealInterval expected )
+	{
+		double err = 0;
+		for ( int d = 0; d < 3; ++d )
+		{
+			err = Math.max( err, Math.abs( actual.realMin( d ) - expected.realMin( d ) ) );
+			err = Math.max( err, Math.abs( actual.realMax( d ) - expected.realMax( d ) ) );
+		}
+		return err;
+	}
+
+	private static double maxAbsDiff( final double[] a, final double[] b )
+	{
+		double m = 0;
+		for ( int d = 0; d < 3; ++d )
+			m = Math.max( m, Math.abs( a[ d ] - b[ d ] ) );
+		return m;
+	}
+
+	@Test
+	public void seededBoundingBoxMatchesExactGroundTruthForDenseLandmarks()
+	{
+		final double[][][] lm = denseLandmarksWithCorners();
+		final Interval bb = BlkThinPlateSplineFusion.inverseTransformedBoundingBox(
+				tps( lm ), approxAffine( lm ), new FinalDimensions( DIMS ) );
+
+		// smallestContainingInterval rounds outward by < 1px, descent tolerance is 0.5px in image space
+		final double err = maxBoundsError( bb, denseExpectedBounds() );
+		assertTrue( err < 2.0, "seeded bounding box deviates from ground truth by " + err + " px: " + Intervals.toString( bb ) );
+	}
+
+	@Test
+	public void seededBoundingBoxIsCorrectForSparseLandmarks()
+	{
+		for ( final double amp : new double[] { 5, 50, 200 } )
+		{
+			final double[][][] lm = sparseSplitCenterLandmarks( amp, 1 );
+			final ThinplateSplineTransform tps = tps( lm );
+			final AffineTransform3D affine = approxAffine( lm );
+
+			// every corner: converged, no fallback, and the result really is a preimage of the corner
+			final GuessingRealTransform inv = new GuessingRealTransform(
+					new WrappedIterativeInvertibleRealTransform<>( tps ), affine, DIMS[ 0 ] );
+			for ( int c = 0; c < 8; ++c )
+			{
+				final double[] p = corner( c );
+				final double[] x = new double[ 3 ];
+				final double[] back = new double[ 3 ];
+				inv.apply( p, x );
+				tps.apply( x, back );
+				assertTrue( maxAbsDiff( back, p ) < GuessingRealTransform.DEFAULT_TOLERANCE,
+						"amp=" + amp + ", corner " + c + ": tps(inverse(corner)) is " + maxAbsDiff( back, p ) + " px off" );
+			}
+			assertEquals( 8, inv.numApplied() );
+			assertEquals( 0, inv.numFallbacks(), "amp=" + amp + ": no corner should need the affine fallback" );
+
+			// the box is close to the affine prediction (the TPS is nearly affine; the un-seeded
+			// inverse is off by ~100,000 px here, see unseededInverseFailsForSparseLandmarks)
+			final Interval bb = BlkThinPlateSplineFusion.inverseTransformedBoundingBox( tps, affine, new FinalDimensions( DIMS ) );
+			final double err = maxBoundsError( bb, affine.estimateBounds( IMAGE ) );
+			assertTrue( err < 500, "amp=" + amp + ": seeded bounding box deviates from affine prediction by " + err + " px: " + Intervals.toString( bb ) );
+		}
+	}
+
+	/**
+	 * Documents why the seed is needed. The plain imglib2 inverse seeds each corner with
+	 * itself (an image coordinate ~50,000 px from the answer) and, for sparse landmarks,
+	 * never converges. If this test ever fails, imglib2 has started seeding properly and
+	 * {@link GuessingRealTransform} may no longer be needed.
+	 */
+	@Test
+	public void unseededInverseFailsForSparseLandmarks()
+	{
+		final double[][][] lm = sparseSplitCenterLandmarks( 5, 1 );
+		final ThinplateSplineTransform tps = tps( lm );
+		final RealTransform unseeded = new WrappedIterativeInvertibleRealTransform<>( tps ).inverse();
+		final RealInterval bb = unseeded.boundingInterval( IMAGE, IntervalSamplingMethod.CORNERS );
+		final RealInterval predicted = approxAffine( lm ).estimateBounds( IMAGE );
+		final double err = maxBoundsError( bb, predicted );
+		System.out.println( "[InverseTransformedBoundingBoxTest] un-seeded imglib2 inverse: " + bb
+				+ "\n  affine prediction: " + predicted + "\n  max deviation = " + err + " px" );
+		assertTrue( err > 1000, "un-seeded inverse unexpectedly converged (deviation " + err + " px); is the seeding workaround still needed?" );
+	}
+
+	@Test
+	public void applyDoesNotModifySourceAndSupportsAliasing()
+	{
+		final double[][][] lm = sparseSplitCenterLandmarks( 50, 1 );
+		final ThinplateSplineTransform tps = tps( lm );
+		final GuessingRealTransform inv = new GuessingRealTransform(
+				new WrappedIterativeInvertibleRealTransform<>( tps ), approxAffine( lm ), DIMS[ 0 ] );
+
+		final double[] corner = corner( 5 );
+		final double[] source = corner.clone();
+		final double[] result = new double[ 3 ];
+		inv.apply( source, result );
+		for ( int d = 0; d < 3; ++d )
+			assertEquals( corner[ d ], source[ d ], 0.0, "apply must not modify source" );
+
+		// Corners.bounds calls apply(pt, pt)
+		final double[] aliased = corner.clone();
+		inv.apply( aliased, aliased );
+		for ( int d = 0; d < 3; ++d )
+			assertEquals( result[ d ], aliased[ d ], 1e-9, "aliased apply(pt, pt) must give the same result" );
+
+		// copy() must be independent (own optimizer state) and give the same answer
+		final double[] fromCopy = new double[ 3 ];
+		inv.copy().apply( corner, fromCopy );
+		for ( int d = 0; d < 3; ++d )
+			assertEquals( result[ d ], fromCopy[ d ], 1e-9, "copy() must give the same result" );
+	}
+}


### PR DESCRIPTION
…fusion code in the transformed package - unrelated)

more importantly, fixing issues reported in https://github.com/JaneliaSciComp/multiview-reconstruction/pull/104/ in a different way, but providing a guess to the inverse TPS. For this we made a compound transformation model that first applies the guess, and then runs the InverseRealTransformGradientDescent, which takes a guess in inverseTol() provided by the source[] in apply().